### PR TITLE
update download file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Tired of manually finding the right url and sha256 hash for a pypi package? This project makes your life easier while still providing the same reproducibility / security.
 
 ### What it does:
-This package comes with a full copy of `url + sha256` for each python package ever published on pypi.org. It is updated on a 12h basis. Checkout the most recent commit if you need recently released packages from pypi. By importing this project you will download around 140 MB (350MB uncompressed) of pypi metadata. Afterwards you can just fetch pypi sources within your nix expressions like this:
+This package comes with a full copy of `url + sha256` for each python package ever published on pypi.org. It is updated on a 12h basis. Checkout the most recent commit if you need recently released packages from pypi. By importing this project you will download around 250 MB (1 GB uncompressed) of pypi metadata. Afterwards you can just fetch pypi sources within your nix expressions like this:
 ```nix
 # pseudo example not including the necessary imports
 


### PR DESCRIPTION
pypi grew quite a bit in the last 12 months

exact values

```
curl -o nix-pypi-fetcher-master.tar.gz https://github.com/DavHau/nix-pypi-fetcher/archive/refs/heads/master.tar.gz
curl -o nix-pypi-fetcher-master.zip https://github.com/DavHau/nix-pypi-fetcher/archive/refs/heads/master.zip
unzip nix-pypi-fetcher-master.zip
du -sh nix-pypi-fetcher-master*
```

```
870M	nix-pypi-fetcher-master
242M	nix-pypi-fetcher-master.tar.gz
241M	nix-pypi-fetcher-master.zip
```

i have rounded these up to 1 GB and 250 MB
